### PR TITLE
Add Electron wrapper and configurable backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,30 @@
 # ProjectTracker
-This is a Flask + HTML + CSS CRUD app for project tracking. It writes to a json "database" and is meant to be run 100% locally.
+This is a Flask + HTML + CSS CRUD app for project tracking. It writes to a JSON "database" and is meant to be run 100% locally.
 
-You can use it by downloading and writing a batch file along the lines of 
+## Running the backend directly
+Set a data directory and optional port via environment variables:
+
 ```
-cd "C:\Users\you\whatever\project_tracker"
-set FLASK_SECRET_KEY=whatever
-"C\Users\you\whatever\python.exe" app.py
-pause
+set PROJECTTRACKER_DATA_DIR=C:\path\to\data
+set PROJECTTRACKER_PORT=5000
+python app.py
 ```
+
+## Electron desktop build
+The `electron/` folder contains a minimal Electron wrapper that spawns the
+Flask backend and loads it in a desktop window. The backend is packaged with
+PyInstaller and shipped as a single executable.
+
+Build steps:
+
+1. Create the backend binary:
+   ```
+   pyinstaller app.py --onefile --add-data "templates;templates" --add-data "static;static" --name projecttracker-backend
+   ```
+   The resulting `dist/projecttracker-backend.exe` is referenced by the Electron config.
+2. From the `electron` directory install dependencies and build:
+   ```
+   npm install
+   npm run dist
+   ```
+   This produces a portable Windows executable that can run from a USB drive.

--- a/anki.py
+++ b/anki.py
@@ -3,7 +3,9 @@ import os
 import uuid
 from datetime import datetime, timedelta
 
-ANKI_FILE = "anki.json"
+DATA_DIR = os.getenv("PROJECTTRACKER_DATA_DIR", os.getcwd())
+os.makedirs(DATA_DIR, exist_ok=True)
+ANKI_FILE = os.path.join(DATA_DIR, "anki.json")
 
 def load_anki_data():
     """Loads flashcard data from JSON file."""
@@ -157,5 +159,5 @@ def process_card_review(card_id, rating):
         # Calculate next review date
         next_date = datetime.now() + timedelta(days=card["interval"])
         card["review_date"] = next_date.strftime("%Y-%m-%d")
-        
+
         save_anki_data(data)

--- a/data_handler.py
+++ b/data_handler.py
@@ -3,7 +3,9 @@ import os
 import uuid
 from datetime import datetime
 
-DATA_FILE = "project_data.json"  # Moved to a constant
+DATA_DIR = os.getenv("PROJECTTRACKER_DATA_DIR", os.getcwd())
+os.makedirs(DATA_DIR, exist_ok=True)
+DATA_FILE = os.path.join(DATA_DIR, "project_data.json")  # Moved to a constant
 
 def load_data():
     """Loads project data from the JSON file."""

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,69 @@
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const path = require('path');
+const { spawn } = require('child_process');
+const Store = require('electron-store');
+const getPort = require('get-port');
+
+const store = new Store();
+let backend;
+let currentPort;
+
+async function startBackend() {
+  currentPort = await getPort();
+  const dataDir = store.get('dataDir') || app.getPath('documents');
+  const env = {
+    ...process.env,
+    PROJECTTRACKER_PORT: String(currentPort),
+    PROJECTTRACKER_DATA_DIR: dataDir,
+  };
+  if (app.isPackaged) {
+    const exe = path.join(process.resourcesPath, 'projecttracker-backend.exe');
+    backend = spawn(exe, [], { env });
+  } else {
+    const script = path.join(__dirname, '..', 'app.py');
+    const python = process.platform === 'win32' ? 'python' : 'python3';
+    backend = spawn(python, [script], { env });
+  }
+  backend.on('exit', (code) => {
+    console.log('Backend exited', code);
+  });
+  await waitForHealth();
+}
+
+async function waitForHealth() {
+  const url = `http://127.0.0.1:${currentPort}/__health`;
+  for (let i = 0; i < 50; i++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch (e) {
+      // ignore
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('Backend failed to start');
+}
+
+async function createWindow() {
+  await startBackend();
+  const win = new BrowserWindow({
+    webPreferences: { preload: path.join(__dirname, 'preload.js') },
+  });
+  win.loadURL(`http://127.0.0.1:${currentPort}`);
+}
+
+app.whenReady().then(createWindow);
+
+app.on('before-quit', () => {
+  if (backend) backend.kill();
+});
+
+ipcMain.handle('choose-data-dir', async () => {
+  const { canceled, filePaths } = await dialog.showOpenDialog({
+    properties: ['openDirectory'],
+  });
+  if (!canceled && filePaths[0]) {
+    store.set('dataDir', filePaths[0]);
+  }
+  return store.get('dataDir');
+});

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "projecttracker-electron",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "dist": "electron-builder --win portable"
+  },
+  "dependencies": {
+    "electron-store": "^8.1.0",
+    "get-port": "^5.1.1"
+  },
+  "devDependencies": {
+    "electron": "^28.0.0",
+    "electron-builder": "^24.0.0"
+  },
+  "build": {
+    "files": [
+      "main.js",
+      "preload.js"
+    ],
+    "extraResources": [
+      {
+        "from": "../dist/projecttracker-backend.exe",
+        "to": "."
+      }
+    ]
+  }
+}

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  chooseDataDir: () => ipcRenderer.invoke('choose-data-dir'),
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,9 @@
             <span class="window-title">{% block window_title %}{% endblock %}</span>
             <div class="window-controls">
                 {% block window_controls %}{% endblock %}
+                <button onclick="window.api && window.api.chooseDataDir && window.api.chooseDataDir()">
+                    Data Folder
+                </button>
             </div>
         </div>
         <div class="main-content">


### PR DESCRIPTION
## Summary
- Load templates/static through `_MEIPASS` and expose `/__health` so the backend can be frozen and polled
- Allow data directory and port to be set via `PROJECTTRACKER_DATA_DIR`/`PROJECTTRACKER_PORT`
- Add Electron wrapper that spawns the backend, chooses a data folder, and packages with electron-builder

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check electron/main.js`
- `node --check electron/preload.js`

------
https://chatgpt.com/codex/tasks/task_e_689f600552208325b9ae84c872d6925e